### PR TITLE
Add docker-compose with simple volume, prometheus and node exporter

### DIFF
--- a/data/prometheus/prometheus.yml
+++ b/data/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 1m
+
+scrape_configs:
+  - job_name: "prometheus"
+    scrape_interval: 1m
+    static_configs:
+    - targets: ["localhost:9090"]
+
+  - job_name: "node"
+    static_configs:
+    - targets: ["node-exporter:9100"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+---
+version: '3.8'
+
+services:
+  prometheus:
+    image: bitnami/prometheus:2.39.1
+    container_name: prometheus
+    volumes:
+      - ./data/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - data-prometheus:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    ports:
+      - 9090:9090
+    networks:
+      - monitor
+  # --
+  node-exporter:
+    image: bitnami/node-exporter:1.4.0
+    container_name: node-exporter
+    restart: unless-stopped
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    expose:
+      - 9100
+    networks:
+      - monitor
+
+networks:
+  monitor:
+    driver: bridge
+
+volumes:
+  data-prometheus: {}
+  data-grafana: {}


### PR DESCRIPTION
```
$ docker-compose up -d
Creating volume "96262-training-application_data-grafana" with default driver
Starting prometheus    ... done
Starting node-exporter ... done

$ docker-compose logs -f prometheus
...
prometheus       | ts=2022-10-25T21:06:26.671Z caller=head.go:709 level=info component=tsdb msg="WAL replay completed" checkpoint_replay_duration=60.564µs wal_replay_duration=12.177427ms wbl_replay_duration=249ns total_replay_duration=12.261648ms
prometheus       | ts=2022-10-25T21:06:26.673Z caller=main.go:1001 level=info fs_type=EXT4_SUPER_MAGIC
prometheus       | ts=2022-10-25T21:06:26.673Z caller=main.go:1004 level=info msg="TSDB started"
prometheus       | ts=2022-10-25T21:06:26.673Z caller=main.go:1184 level=info msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
prometheus       | ts=2022-10-25T21:06:26.673Z caller=main.go:1221 level=info msg="Completed loading of configuration file" filename=/etc/prometheus/prometheus.yml totalDuration=395.798µs db_storage=807ns remote_storage=1.109µs web_handler=633ns query_engine=571ns scrape=145.446µs scrape_sd=39.626µs notify=1.223µs notify_sd=2.392µs rules=929ns tracing=4.966µs
....

$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' node-exporter
172.23.0.3

$ curl -s http://172.23.0.3:9100/metrics | tail
promhttp_metric_handler_errors_total{cause="encoding"} 251
promhttp_metric_handler_errors_total{cause="gathering"} 0
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 16
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```